### PR TITLE
On Python 3, check manually for no command supplied case

### DIFF
--- a/aws-system-tools.py
+++ b/aws-system-tools.py
@@ -670,7 +670,10 @@ if __name__ == '__main__':
 
     args = parser.parse_args()
     data = args.__dict__
-    func = data.pop('func')
+    func = data.pop('func', None)
+    if func is None:
+        parser.print_usage()
+        raise SystemExit(0)
     args.verbose and log("command '%s' ..." % func.__name__, "info")
 
     global g


### PR DESCRIPTION
This closes https://github.com/Birdback/aws-linux-system-tools/issues/10.